### PR TITLE
[dev] update max_time before which backoff gives up

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -178,7 +178,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
     @backoff.on_exception(
         backoff.expo,
         botocore.exceptions.ClientError,
-        max_time=600,
+        max_time=120, # reduce the max time after which function gives up 
         on_backoff=backoff_handler,
     )
     def inner_function(*args, **kwargs):  # type: ignore


### PR DESCRIPTION
From the backoff package

`Give Up Conditions
Optional keyword arguments can specify conditions under which to give up.
The keyword argument max_time specifies the maximum amount of total time in seconds that can elapse before giving up.
` 
