### PR TITLE
Enable GCP Support

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -236,6 +236,22 @@ class CLI:
             ),
         )
         parser.add_argument(
+            '--borneo-gcp-creds',
+            type=str,
+            default=None,
+            help=(
+                'Path to GCP Creds file'
+            ),
+        )
+        parser.add_argument(
+            '--borneo-gcp-project',
+            type=str,
+            default=None,
+            help=(
+                'GCP Project Name'
+            ),
+        )
+        parser.add_argument(
             '--crxcavator-api-base-uri',
             type=str,
             default='https://api.crxcavator.io/v1',
@@ -446,9 +462,16 @@ class CLI:
         """
         # TODO support parameter lookup in environment variables if not present on command line
         config: argparse.Namespace = self.parser.parse_args(argv)
-        
-        os.environ['AWS_PROFILE'] = config.borneo_aws_profile
-        os.environ['AWS_CONFIG_FILE'] = config.borneo_aws_config
+
+        if config.borneo_aws_profile is not None:
+            os.environ['AWS_PROFILE'] = config.borneo_aws_profile
+        if config.borneo_aws_config is not None:
+            os.environ['AWS_CONFIG_FILE'] = config.borneo_aws_config
+        if config.borneo_gcp_creds is not None:
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = config.borneo_gcp_creds
+        if config.borneo_gcp_project is not None:
+            os.environ["GOOGLE_CLOUD_PROJECT"] = config.borneo_gcp_project
+
         # Logging config
         if config.verbose:
             logging.getLogger('cartography').setLevel(logging.DEBUG)
@@ -595,8 +618,12 @@ def main(argv=None, sync_flag=None):
     logging.getLogger('neo4j').setLevel(logging.WARNING)
     argv = argv if argv is not None else sys.argv[1:]
     requested_sync = sync_flag if sync_flag is not None else 'default'
+    logger.info("Running cartography sync with requested sync: %s", requested_sync)
     if(requested_sync == 'rule_check'):
         sync = cartography.sync.build_rule_check_sync()
+        result = CLI(sync, prog='cartography').main(argv)
+    if(requested_sync.startswith("gcp")):
+        sync = cartography.sync.build_borneo_gcp_sync("skip_index" in requested_sync)
         result = CLI(sync, prog='cartography').main(argv)
     else:
         if(requested_sync != "default"):

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -199,6 +199,16 @@ def build_default_borneo_sync(skipIndex: bool) -> Sync:
     ])
     return sync
 
+def build_borneo_gcp_sync(skipIndex: bool) -> Sync:
+    sync = Sync()
+    if skipIndex != True:
+        sync.add_stages([('create-indexes', cartography.intel.create_indexes.run)])
+    sync.add_stages([
+        ('gcp', cartography.intel.gcp.start_gcp_ingestion),
+        ('analysis', cartography.intel.analysis.run)
+    ])
+    return sync
+
 def build_rule_check_sync() -> Sync:
     sync = Sync()
     sync.add_stages([


### PR DESCRIPTION
Add borneo specific cli args to get credentials for a federated IAM service account.

Change auth library from oauth2lib to google-auth. oauth2lib does not support federated IAM and is deprecated in favour of google-auth