### PR TITLE
Add support for scanning Azure accounts from cartography-service

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -66,6 +66,10 @@ def start_azure_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             credentials = Authenticator().authenticate_sp(
                 config.azure_tenant_id, config.azure_client_id, config.azure_client_secret,
             )
+        elif config.borneo_azure_federated_auth:
+            credentials = Authenticator().authenticate_federated_principal(
+                config.azure_tenant_id, config.azure_client_id, config.azure_client_secret,
+            )
         else:
             credentials = Authenticator().authenticate_cli()
 

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -209,6 +209,17 @@ def build_borneo_gcp_sync(skipIndex: bool) -> Sync:
     ])
     return sync
 
+def build_borneo_azure_sync(skipIndex: bool) -> Sync:
+    sync = Sync()
+    if skipIndex != True:
+        sync.add_stages([('create-indexes', cartography.intel.create_indexes.run)])
+    sync.add_stages([
+        ('azure', cartography.intel.azure.start_azure_ingestion),
+        ('analysis', cartography.intel.analysis.run)
+    ])
+    return sync
+
+
 def build_borneo_okta_sync(skipIndex: bool) -> Sync:
     sync = Sync()
     if skipIndex != True:


### PR DESCRIPTION
Accepts client secret from command line args instead of env variable

Add a new method to authenticate Azure Federated Service Principal

The new method is activated by the command line arg: --borneo-azure-federated-auth

Then a ClientAssertionCredential method is used to authenticate.

Refer: https://www.keepsecure.ca/blog/2023/cross-cloud_authentication/